### PR TITLE
Fix grid-auto-rows property name

### DIFF
--- a/assets/scss/utils/_grid.scss
+++ b/assets/scss/utils/_grid.scss
@@ -46,8 +46,8 @@ $grid-utilities: (
     ),
     responsive: true,
   ),
-  "grid-auto-row": (
-    property: grid-auto-row,
+  "grid-auto-rows": (
+    property: grid-auto-rows,
     class: auto-rows,
     values: (
       "auto": auto,


### PR DESCRIPTION
Fix a typo that causes invalid CSS for the `grid-auto-rows` property.