### PR TITLE
Set generic css variables to be able to edit global properties easily

### DIFF
--- a/assets/scss/elements/_global.scss
+++ b/assets/scss/elements/_global.scss
@@ -21,7 +21,11 @@ body {
 // -----------------------------------------------------------------------------
 
 * {
-  &:focus {
+  &:focus:not(:focus-visible) {
+    outline: 0;
+  }
+
+  &:focus-visible {
     outline: var(--focus-outline, 1px dashed var(--color-contrast-300));
     outline-offset: var(--focus-outline-offset, 0.15em);
   }

--- a/assets/scss/elements/_global.scss
+++ b/assets/scss/elements/_global.scss
@@ -10,11 +10,11 @@ html {
 }
 
 body {
-  color: var(--color-contrast-900);
-  font-size: var(--text-sm);
-  font-family: var(--font-sans);
-  line-height: var(--leading-normal);
-  background: var(--color-contrast-0, white);
+  color: var(--body-text-color, var(--color-contrast-900));
+  font-size: var(--body-text-size, var(--text-sm));
+  font-family: var(--body-font-family, var(--font-sans));
+  line-height: var(--body-leading, var(--leading-normal));
+  background: var(--body-background-color, var(--color-contrast-0));
 }
 
 // Focus state
@@ -22,8 +22,8 @@ body {
 
 * {
   &:focus {
-    outline: 1px dashed var(--color-contrast-300);
-    outline-offset: 0.15em;
+    outline: var(--focus-outline, 1px dashed var(--color-contrast-300));
+    outline-offset: var(--focus-outline-offset, 0.15em);
   }
 }
 
@@ -31,8 +31,8 @@ body {
 // -----------------------------------------------------------------------------
 
 ::selection {
-  color: var(--color-contrast-0);
-  background-color: var(--color-primary-500);
+  color: var(--selection-text-color, var(--color-contrast-0));
+  background-color: var(--selection-background-color, var(--color-primary-500));
 }
 
 // Animations


### PR DESCRIPTION
CSS variables in the global aren't set but they have a default value.

Thus, the property values can be customized simply by declaring these variables in a project.