### PR TITLE
Remove useless font-face mixin

### DIFF
--- a/assets/scss/tools/_mixins.scss
+++ b/assets/scss/tools/_mixins.scss
@@ -2,27 +2,6 @@
 // Mixins
 // -----------------------------------------------------------------------------
 
-// Font-face
-// -----------------------------------------------------------------------------
-
-@mixin font-face(
-  $font-name,
-  $font-local-1,
-  $font-local-2,
-  $font-path,
-  $font-file,
-  $font-weight: normal,
-  $font-style: normal
-) {
-  font-weight: $font-weight;
-  font-family: $font-name;
-  font-style: $font-style;
-  font-display: "swap";
-  src: local($font-local-1), local($font-local-2),
-    url("../../fonts/#{$font-path}/#{$font-file}.woff2") format("woff2"),
-    url("../../fonts/#{$font-path}/#{$font-file}.woff") format("woff");
-}
-
 // Breakpoints
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
There are several ways to declare a custom font and it's not a good idea to create a mixin with almost all the properties as parameters.

Using this mixin generate a lesser readable code than declare it all the CSS way.