### PR TITLE
Remove useless unstyled placeholders

### DIFF
--- a/assets/scss/tools/_placeholders.scss
+++ b/assets/scss/tools/_placeholders.scss
@@ -30,23 +30,6 @@
   clip-path: inset(50%);
 }
 
-// Unstyled
-// -----------------------------------------------------------------------------
-
-%list-unstyled {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 0;
-  list-style: none;
-}
-
-%btn-unstyled {
-  padding: 0;
-  background: none;
-  border: 0;
-  cursor: pointer;
-}
-
 // Ellipsis
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
With the new reset, there is no need for Sass placeholders to remove default styles on lists and buttons. Their styles are already completely withdrawn.