### PR TITLE
Prevent automatic text size adjustment by the browser

### DIFF
--- a/assets/scss/elements/_reset.scss
+++ b/assets/scss/elements/_reset.scss
@@ -18,6 +18,15 @@
   box-sizing: border-box;
 }
 
+// Text
+// -----------------------------------------------------------------------------
+
+// Prevent Mobile Safari browser to increase the default font-size
+html {
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
+}
+
 // Lists
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Based on this article: https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/ and some others, I also think it's a good idea to include a `text-size-adjust: none;` to the reset.